### PR TITLE
Fix indentation with HereDocs

### DIFF
--- a/lib/PPI/HTML.pm
+++ b/lib/PPI/HTML.pm
@@ -242,12 +242,12 @@ sub _heredoc_fragments {
 	# First, create the heredoc content lines and add them
 	# to the buffer
 	foreach my $line ( $Token->heredoc ) {
-		$self->_add_heredoc( $line,
+		$self->_add_heredoc( $Token->indentation . $line,
 			'heredoc_content' ) or return ();
 	}
 
 	# Add the terminator line
-	$self->_add_heredoc( $Token->terminator . "\n",
+	$self->_add_heredoc( $Token->indentation . $Token->terminator . "\n",
 		'heredoc_terminator' ) or return ();
 
 	# Return a single fragment for the main content part


### PR DESCRIPTION
Making good usage of [indentation](https://github.com/Perl-Critic/PPI/blob/master/lib/PPI/Token/HereDoc.pm#L117) sub to reapply indentation removed (for good reasons) in PPI

Related to https://github.com/perladvent/Perl-Advent/issues/368